### PR TITLE
Updating configuration env var names

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,9 +8,9 @@ Bundler.require
 $: << File.expand_path('../', __FILE__)
 
 Kubr.configure do |config|
-  config.url = "#{ENV['KUBERNETES_API_ENDPOINT']}/api/v1beta1"
-  config.username = ENV['API_USERNAME']
-  config.password = ENV['API_PASSWORD']
+  config.url = "#{ENV['KUBERNETES_MASTER']}/api/v1beta1"
+  config.username = ENV['KUBERNETES_USERNAME']
+  config.password = ENV['KUBERNETES_PASSWORD']
 end
 
 # Require base


### PR DESCRIPTION
Choosing `KUBERNETES_MASTER` over `KUBERNETES_API_ENDPOINT` since that is the same name that Kubernetes uses for it's own tools.

Renaming the usernames/password vars just to make them consistent.
