### PR TITLE
Scale repl controllers to 0 before deletion

### DIFF
--- a/app/models/replication_controller.rb
+++ b/app/models/replication_controller.rb
@@ -21,7 +21,15 @@ module KubernetesAdapter
         kubr.create_replication_controller(to_hash)
       end
 
+      def stop
+        # stop controller by scaling it to zero
+        rc = kubr.get_replication_controller(id)
+        rc[:desiredState][:replicas] = 0
+        kubr.update_replication_controller(id, rc)
+      end
+
       def destroy
+        stop
         kubr.delete_replication_controller(id)
       end
 

--- a/spec/models/replication_controller_spec.rb
+++ b/spec/models/replication_controller_spec.rb
@@ -197,7 +197,35 @@ describe KubernetesAdapter::Models::ReplicationController do
     end
   end
 
+  context '#stop' do
+    let(:rc) { { desiredState: {} } }
+
+    before do
+      allow(client).to receive(:get_replication_controller).and_return(rc)
+      allow(client).to receive(:update_replication_controller)
+    end
+
+    it 'scales the replication controller to 0' do
+      expect(client).to receive(:update_replication_controller) do |id, rc|
+        expect(id).to eq attrs[:id]
+        expect(rc).to eq({ desiredState: { replicas: 0 } })
+      end
+
+      subject.stop
+    end
+  end
+
   context '#destroy' do
+    before do
+      allow(subject).to receive(:stop)
+      allow(client).to receive(:delete_replication_controller)
+    end
+
+    it 'stops the replication controller' do
+      expect(subject).to receive(:stop)
+      subject.destroy
+    end
+
     it 'invokes delete_replication_controller on the Kubr client' do
       expect(client).to receive(:delete_replication_controller).with(attrs[:id])
       subject.destroy


### PR DESCRIPTION
In order to get the replication controller to clean-up its pods prior to deletion we need to first set the controller's scale to zero.
